### PR TITLE
Update Parser.py

### DIFF
--- a/Parser.py
+++ b/Parser.py
@@ -377,6 +377,7 @@ def parse(tokenList, typedef, cfg, action=None, goto=None, needLog=False):
 
     # lexStr is the lexical string; token type is int.
     for lexStr, tokenType in tokenList:
+        tokenType = str(tokenType)
         currentState = stateStack[-1]
         while True:
             if action[currentState][tokenType] is None:


### PR DESCRIPTION
# Describe the bug
Parser.parse raises KeyError for `python3 simpleJavaCompiler.py`

# Error infomation:

> Exception has occurred: KeyError
20
  File "newCompilerTest/Parser.py", line 382, in parse
    if action[currentState][tokenType] is None:
  File "newCompilerTest/simpleJavaCompiler.py", line 395, in <module>
    pt = Parser.parse(tokenList, typedef, cfg, action, goto)
KeyError: 20

# reason:
tokenType is integer but required str

# solution:
add a type transformation in Parser.py:380
```python
tokenType = str(tokenType)
```